### PR TITLE
Block Scoping

### DIFF
--- a/phase2-w25/include/parser.h
+++ b/phase2-w25/include/parser.h
@@ -17,6 +17,7 @@ typedef enum {
     AST_IF,
     AST_WHILE,
     AST_BLOCK, 
+    AST_BLOCK_END, 
     AST_STRING,
     AST_REPEAT,
     AST_FACTORIAL,

--- a/phase2-w25/src/parser/parser.c
+++ b/phase2-w25/src/parser/parser.c
@@ -174,16 +174,26 @@ static ASTNode *parse_block(void) {
             prev->right = curr;
         }
         prev = curr;
+        print_ast(node, 0);
+        printf("\n********\n");
     }
     if (!match(TOKEN_RBRACE)) {
         parse_error(PARSE_ERROR_MISSING_BRACKET, current_token);
         synchronize();
     } else {
+        ASTNode *closing_brace_node = create_node(AST_BLOCK_END);
+        closing_brace_node->token = current_token;
+        if (prev) {
+            prev->right->right = closing_brace_node;
+        } else {
+            node->left = closing_brace_node;
+        }
         advance();
     }
 
     return node;
 }
+
 
 // Parse: if (condition) { ... }
 static ASTNode *parse_if(void) {
@@ -437,6 +447,7 @@ void print_ast_node(ASTNode* node) {
         case AST_IF:         printf("AST_IF\n"); break;
         case AST_WHILE:      printf("AST_WHILE\n"); break;
         case AST_BLOCK:      printf("AST_BLOCK\n"); break;
+        case AST_BLOCK_END:      printf("AST_BLOCK_END\n"); break;
         case AST_STRING:     printf("AST_STRING\n"); break;
         case AST_REPEAT:     printf("AST_REPEAT\n"); break;
         case AST_FACTORIAL:  printf("AST_FACTORIAL\n"); break;
@@ -521,6 +532,9 @@ void print_ast(ASTNode *node, int level) {
             break;
         case AST_BLOCK:
             printf("Block: %s\n", node->token.lexeme);
+            break;
+        case AST_BLOCK_END:
+            printf("Block End: %s\n", node->token.lexeme);
             break;
         case AST_WHILE:
             printf("While: %s\n", node->token.lexeme); 

--- a/phase2-w25/src/semantic/semantic.c
+++ b/phase2-w25/src/semantic/semantic.c
@@ -81,6 +81,10 @@ int check_assignment(ASTNode* node, SymbolTable* table){
     // If assigning to an identifier, check that the identifier is initialized
     if (node->right->type == AST_IDENTIFIER){
         Symbol* right = lookup_symbol(table, node->right->token.lexeme);
+        if (right == NULL){
+            semantic_error(SEM_ERROR_UNDECLARED_VARIABLE, node->right->token.lexeme, node->token.line);
+            return 1;
+        }
         if (right->is_initialized == 0){ 
             semantic_error(SEM_ERROR_UNINITIALIZED_VARIABLE, node->right->token.lexeme, node->token.line);
             return 1;

--- a/phase2-w25/src/semantic/semantic.c
+++ b/phase2-w25/src/semantic/semantic.c
@@ -119,14 +119,17 @@ int process_node(ASTNode* node, SymbolTable* table) {
             error = check_expression(node, table);
             break;
         
+        case AST_BLOCK:
+            enter_scope(table);
+            break;
+        
+        case AST_BLOCK_END:
+            exit_scope(table);
+            break;
+
+
         default:
             break;
-        //         case AST_ASSIGN:
-//             error = check_assignment(node, table);
-//             break;
-//         case AST_BLOCK:
-//             error = check_declaration(node, table);
-//             break;
     }
     if (node->left) error += process_node(node->left, table);
     if (node->right) error += process_node(node->right, table);

--- a/phase2-w25/test/input_invalid.txt
+++ b/phase2-w25/test/input_invalid.txt
@@ -1,3 +1,11 @@
 int y;
 int x;
+x = 4;
+if (y < 3){
+    x = 5;
+    int z;
+    z = 6;
+}
+
+
 y = x + 5;

--- a/phase2-w25/test/input_valid.txt
+++ b/phase2-w25/test/input_valid.txt
@@ -7,7 +7,7 @@ if(x < 5){
     a = 6;
     if(x < 4){
         int b;
-        b = 5;
+        b = a + 5;
     }
 
     while(y < 7){

--- a/phase2-w25/test/input_valid.txt
+++ b/phase2-w25/test/input_valid.txt
@@ -8,6 +8,9 @@ if(x < 5){
     if(x < 4){
         int b;
         b = a + 5;
+        if (b > a){
+            int g;
+        }
     }
 
     while(y < 7){

--- a/phase2-w25/test/input_valid.txt
+++ b/phase2-w25/test/input_valid.txt
@@ -1,5 +1,20 @@
 int x;
 int y;
-x = 5;
-y = x;
-y = x + 5;
+y = 4;
+x = 3;
+if(x < 5){
+    int a;
+    a = 6;
+    if(x < 4){
+        int b;
+        b = 5;
+    }
+
+    while(y < 7){
+        int c;
+        c = 5;
+    }
+    int d;
+    d = 3;
+}
+x = 6;


### PR DESCRIPTION
- Fixed parser to handle multiple nested blocks
- Allowed var shadowing by searching for var with the highest scope (those declared latest)
- Entering a block increases the tables current scope, exiting decreases and deletes all vars within that scope

Issue Tasks:
- [x] Implement block scoping rules
- [x] Track variables across nested scopes
- [x] Handle variable shadowing correctly